### PR TITLE
Add Code of Conduct using Contributor Covenant

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Code of Conduct (Contributor Covenant)
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people  
+- Being respectful of differing opinions, viewpoints, and experiences  
+- Giving and gracefully accepting constructive feedback  
+- Taking responsibility and apologizing to those affected by mistakes  
+- Focusing on what benefits the entire community, not just the individual
+
+Examples of unacceptable behavior include:
+
+- Sexual language or imagery, or sexual attention or advances of any kind  
+- Trolling, insulting or derogatory comments, and personal or political attacks  
+- Public or private harassment  
+- Publishing private information (e.g., address, email) without consent  
+- Other behavior inappropriate for professional/community environments
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing these standards
+and will take appropriate and fair corrective action in response to any behavior
+they deem inappropriate, threatening, offensive, or harmful. They may remove,
+edit, or reject comments, commits, code, or contributions that do not follow
+this Code of Conduct, and will explain moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces—e.g.,
+using an official email, social media account, or acting as an appointed
+representative at events.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders via the Paxi Discord: **https://discord.com/invite/rA9Xzs69tx**.  
+All reports will be reviewed and addressed promptly and fairly.
+
+All community leaders are expected to maintain the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+The following guidelines outline consequences for violations of the Code of
+Conduct:
+
+| Severity         | Consequence                                                                 |
+|-----------------|------------------------------------------------------------------------------|
+| 1. Correction    | Private warning with explanation; public apology may be requested            |
+| 2. Warning       | Formal warning; restricted access for a specified period                     |
+| 3. Temporary Ban | Temporary ban from community interactions until resolution                   |
+| 4. Permanent Ban | Permanent exclusion from community spaces                                    |
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at  
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+
+[homepage]: https://www.contributor-covenant.org


### PR DESCRIPTION
This PR adds a Code of Conduct file based on Contributor Covenant 2.1 to establish clear community guidelines and expectations.

Report Issues / Harassment:
- Use the official Paxi Discord: https://discord.com/invite/rA9Xzs69tx
